### PR TITLE
Line search

### DIFF
--- a/Code/Source/svFSI/LS.f
+++ b/Code/Source/svFSI/LS.f
@@ -377,13 +377,13 @@
 !     PICC
       alpha = 0.0
       CALL CALCG(An0, Yn0, Dn0, DA0, alpha, g_0)
-      IF (cm%mas()) THEN PRINT*, "alpha_0", alpha_0, "g_0", g_0
+      IF (cm%mas()) PRINT*, "alpha_0", alpha, "g_0", g_0
 !     Compute scalar gunction g at alpha = 1 (the full Newton step)
 !     Note that CALCG calls PICC, so after this call, the global state variables
 !     An, Yn, Dn are set to values after a full Newton step. 
       alpha = 1.0
       CALL CALCG(An0, Yn0, Dn0, DA0, alpha, g_1)
-      IF (cm%mas()) THEN PRINT*, "alpha_1", alpha_1, "g_1", g_1
+      IF (cm%mas()) PRINT*, "alpha_1", alpha, "g_1", g_1
 
 !     Choose which root-finding algorithm to use.
       algo = 2
@@ -400,7 +400,7 @@
             it = 1
             DO
                   ! Check if residual is reduced enough. If so, return
-                  IF (ABS(g_k) < 0.8 * ABS(g_0)
+                  IF (ABS(g_k) < 0.5 * ABS(g_0)
      2                .OR. it .GT. maxit) THEN
                         RETURN
                   END IF
@@ -416,7 +416,7 @@
 
                   
             END DO
-         ELSE IF (algo .EQ. 2) THEN ! Algorithm 2: Regula falsi
+         ELSE IF (algo .EQ. 2) THEN ! Algorithm 2: Regula falsi (https://en.wikipedia.org/wiki/Regula_falsi)
 
 !           Compute g(alpha = 0)
             a = 0
@@ -430,9 +430,12 @@
             c = 1
             g_c = g_b
 
+!           Iteration counter and max iteration
+            maxit = 10
+            it = 1
             DO
 !              Check if residual is reduced enough. If so, return
-               IF (ABS(g_c) < 0.8 * ABS(g_0)
+               IF (ABS(g_c) < 0.5 * ABS(g_0)
      2             .OR. it .GT. maxit) THEN
                         RETURN
                END IF
@@ -443,9 +446,9 @@
 !              Compute g(c)
                CALL CALCG(An0, Yn0, Dn0, DA0, c, g_c)
 
-               IF (cm%mas()) THEN PRINT*, "a", a, "g_a", g_a
-               IF (cm%mas()) THEN PRINT*, "b", b, "g_b", g_b
-               IF (cm%mas()) THEN PRINT*, "c", c, "g_c", g_c
+               IF (cm%mas()) PRINT*, "a", a, "g_a", g_a
+               IF (cm%mas()) PRINT*, "b", b, "g_b", g_b
+               IF (cm%mas()) PRINT*, "c", c, "g_c", g_c
 !              Update a or b depending on g_c
                IF (g_a*g_c .GT. 0.0) THEN 
                   a = c
@@ -454,6 +457,8 @@
                   b = c
                   g_b = g_c
                END IF
+
+               it = it + 1
             END DO
          END IF
       END IF

--- a/Code/Source/svFSI/LS.f
+++ b/Code/Source/svFSI/LS.f
@@ -187,25 +187,27 @@
 !     During line search loop, don't need to compute and assemble tangent
 !
 !     TODO: Wrap tangent calculation in kflag IF statements
-      SUBROUTINE CALCKR(kflag)
+      SUBROUTINE CALCKR(kflag, lEq, incL, res)
       USE COMMOD
       USE ALLFUN
       IMPLICIT NONE
       LOGICAL, INTENT(IN) :: kflag
+      TYPE(eqType), INTENT(INOUT) :: lEq
+      INTEGER(KIND=IKIND), INTENT(INOUT) :: incL(nFacesLS)
+      REAL(KIND=RKIND), INTENT(INOUT) :: res(nFacesLS) ! Neumann cplBC resistance
+
 
       LOGICAL l1, l2, l3
-      INTEGER(KIND=IKIND) i, iM, iBc, ierr, iEqOld, stopTS
+      INTEGER(KIND=IKIND) i, iM, iBc, ierr, stopTS
       REAL(KIND=RKIND) timeP(3)
 
-      INTEGER(KIND=IKIND), ALLOCATABLE :: incL(:)
-      REAL(KIND=RKIND), ALLOCATABLE :: Ag(:,:), Yg(:,:), Dg(:,:), res(:)
+      REAL(KIND=RKIND), ALLOCATABLE :: Ag(:,:), Yg(:,:), Dg(:,:)
 
       dbg = 'Allocating intermediate variables'
-      ALLOCATE(Ag(tDof,tnNo), Yg(tDof,tnNo), Dg(tDof,tnNo),
-     2   res(nFacesLS), incL(nFacesLS))
+      ALLOCATE(Ag(tDof,tnNo), Yg(tDof,tnNo), Dg(tDof,tnNo))
 
 
-      iEqOld = cEq
+      
 !     If cplBC is being used, compute cplBC quantities (pressure, flowrate, resistance)
 !     by communicating with cplBC/genBC
 !     cplBC is invoked only for the first equation

--- a/Code/Source/svFSI/MAIN.f
+++ b/Code/Source/svFSI/MAIN.f
@@ -116,6 +116,9 @@
 
 !     Inner loop for iteration
          DO
+
+!           BEGIN CALCKR. Remove eq(cEq)%itr = eq(cEq)%itr + 1 from PICI
+
             iEqOld = cEq
 !           If cplBC is being used, compute cplBC quantities (pressure, flowrate, resistance)
 !           by communicating with cplBC/genBC
@@ -200,9 +203,11 @@
                END IF
             END DO
 
+!           END CALCKR
             dbg = "Solving equation <"//eq(cEq)%sym//">"
             CALL LSSOLVE(eq(cEq), incL, res)
 
+<<<<<<< Updated upstream
 !        AB 3/2/23: Want line search loop here. Modifies R <- alpha*R, where R
 !        is the Newton increment
             CALL LINESEARCH
@@ -214,8 +219,15 @@
                CONTINUE
 
 !        Solution is obtained (in R), now updating (Corrector)
+=======
+!           ADD LINE SEARCH LOOP HERE
+
+!        Solution is obtained, now updating (Corrector)
+>>>>>>> Stashed changes
 !        Note the corrector step inside the NR loop, which is
 !        slightly different from https://www.scorec.rpi.edu/~kjansen/genalf.pdf
+!        
+!           REMOVE convergence checks and equation increment from PICC
             CALL PICC
 
 !        Checking for exceptions

--- a/Code/Source/svFSI/MAIN.f
+++ b/Code/Source/svFSI/MAIN.f
@@ -114,7 +114,7 @@
 !     Apply Dirichlet BCs strongly
          CALL SETBCDIR(An, Yn, Dn)
 
-!     Inner loop for iteration
+!     Inner loop for Newton iteration (with line search)
          DO
             iEqOld = cEq
 

--- a/Code/Source/svFSI/MAIN.f
+++ b/Code/Source/svFSI/MAIN.f
@@ -118,7 +118,11 @@
          DO
             iEqOld = cEq
 
-!           BEGIN CALCKR. Remove eq(cEq)%itr = eq(cEq)%itr + 1 from PICI
+!           Increment Newton iteration counter
+            eq(cEq)%itr = eq(cEq)%itr + 1
+
+
+!           BEGIN CALCKR.
             kflag = .TRUE.
             CALL CALCKR(kflag, eq(cEq), incL, res)
 !           END CALCKR

--- a/Code/Source/svFSI/MAIN.f
+++ b/Code/Source/svFSI/MAIN.f
@@ -207,23 +207,9 @@
             dbg = "Solving equation <"//eq(cEq)%sym//">"
             CALL LSSOLVE(eq(cEq), incL, res)
 
-<<<<<<< Updated upstream
-!        AB 3/2/23: Want line search loop here. Modifies R <- alpha*R, where R
-!        is the Newton increment
-            CALL LINESEARCH
-         
-!        Or this 
-            IF (linesearch) THEN
-               CALL LINESEARCH
-               CALL PICC()
-               CONTINUE
-
-!        Solution is obtained (in R), now updating (Corrector)
-=======
 !           ADD LINE SEARCH LOOP HERE
 
 !        Solution is obtained, now updating (Corrector)
->>>>>>> Stashed changes
 !        Note the corrector step inside the NR loop, which is
 !        slightly different from https://www.scorec.rpi.edu/~kjansen/genalf.pdf
 !        

--- a/Code/Source/svFSI/MAIN.f
+++ b/Code/Source/svFSI/MAIN.f
@@ -203,7 +203,17 @@
             dbg = "Solving equation <"//eq(cEq)%sym//">"
             CALL LSSOLVE(eq(cEq), incL, res)
 
-!        Solution is obtained, now updating (Corrector)
+!        AB 3/2/23: Want line search loop here. Modifies R <- alpha*R, where R
+!        is the Newton increment
+            CALL LINESEARCH
+         
+!        Or this 
+            IF (linesearch) THEN
+               CALL LINESEARCH
+               CALL PICC()
+               CONTINUE
+
+!        Solution is obtained (in R), now updating (Corrector)
 !        Note the corrector step inside the NR loop, which is
 !        slightly different from https://www.scorec.rpi.edu/~kjansen/genalf.pdf
             CALL PICC

--- a/Code/Source/svFSI/OUTPUT.f
+++ b/Code/Source/svFSI/OUTPUT.f
@@ -87,6 +87,10 @@
       ELSE
          ! Computing convergence metrics to be printed to output
          ! What are all these norms?
+         ! FSILS%RI%iNorm is the norm of the residual at iteration k (before linear solve). R(t, k)
+         ! iNorm is the norm of the residual at iteration t = 0. R(t = 0)
+         ! pNorm is R(t, k = 0) / R(t = 0)
+         ! FSILS%RI%fNorm is the linear solver residual (after linear solve). KU - R(t, k)
          tmp  = eq(iEq)%FSILS%RI%iNorm/eq(iEq)%iNorm
          tmp1 = tmp/eq(iEq)%pNorm
          tmp2 = eq(iEq)%FSILS%RI%fNorm/eq(iEq)%FSILS%RI%iNorm

--- a/Code/Source/svFSI/PIC.f
+++ b/Code/Source/svFSI/PIC.f
@@ -285,23 +285,7 @@
       IF (l1 .OR. l2 .OR. ((l3.OR.l4).AND.l5)) eq(cEq)%ok = .TRUE.
       IF (ALL(eq%ok)) RETURN
 
-      IF (eq(cEq)%coupled) THEN
-         cEq = cEq + 1
-         IF (ALL(.NOT.eq%coupled .OR. eq%ok)) THEN
-            DO WHILE (cEq .LE. nEq)
-               IF (.NOT.eq(cEq)%coupled) EXIT
-               cEq = cEq + 1
-            END DO
-         ELSE
-            IF (cEq .GT. nEq) cEq = 1
-            DO WHILE (.NOT.eq(cEq)%coupled)
-               cEq = cEq + 1
-               IF (cEq .GT. nEq) cEq = 1
-            END DO
-         END IF
-      ELSE
-         IF (eq(cEq)%ok) cEq = cEq + 1
-      END IF
+      
 
       RETURN
       END SUBROUTINE PICC

--- a/Code/Source/svFSI/PIC.f
+++ b/Code/Source/svFSI/PIC.f
@@ -143,8 +143,7 @@
       INTEGER(KIND=IKIND) s, e, i, a
       REAL(KIND=RKIND) coef(4)
 
-      dof         = eq(cEq)%dof
-      eq(cEq)%itr = eq(cEq)%itr + 1
+      dof         = eq(cEq)%dof ! UNUSED?
 
       DO i=1, nEq
          s       = eq(i)%s

--- a/Code/Source/svFSI/PIC.f
+++ b/Code/Source/svFSI/PIC.f
@@ -172,7 +172,7 @@
       END SUBROUTINE PICI
 !====================================================================
 !     This is the corrector. Decision for next eqn is also made here
-      SUBROUTINE PICC(Ag, Yg, Dg)
+      SUBROUTINE PICC
       USE COMMOD
       USE ALLFUN
       IMPLICIT NONE
@@ -267,9 +267,6 @@
 !     IB treatment
       IF (ibFlag) CALL IB_PICC()
 
-      IF (linesearch) THEN 
-         RETURN
-      END
 !     Check for convergence or max iterations of Newton-Raphson iteration
       IF (ISZERO(eq(cEq)%FSILS%RI%iNorm)) eq(cEq)%FSILS%RI%iNorm = eps
       IF (ISZERO(eq(cEq)%iNorm)) eq(cEq)%iNorm = eq(cEq)%FSILS%RI%iNorm

--- a/Code/Source/svFSI/PIC.f
+++ b/Code/Source/svFSI/PIC.f
@@ -283,9 +283,7 @@
       l4 = r1 .LE. eq(cEq)%tol*eq(cEq)%pNorm
       l5 = eq(cEq)%itr .GE. eq(cEq)%minItr
       IF (l1 .OR. l2 .OR. ((l3.OR.l4).AND.l5)) eq(cEq)%ok = .TRUE.
-
       IF (ALL(eq%ok)) RETURN
-
 
       IF (eq(cEq)%coupled) THEN
          cEq = cEq + 1

--- a/Code/Source/svFSILS/GMRES.f
+++ b/Code/Source/svFSILS/GMRES.f
@@ -295,7 +295,9 @@
 
       ls%callD  = FSILS_CPUT()
       ls%suc    = .FALSE.
+!     Compute norm of residual
       eps       = FSILS_NORMV(dof, mynNo, lhs%commu, R)
+!     ls = ls%RI 
       ls%iNorm  = eps
       ls%fNorm  = eps
       eps       = MAX(ls%absTol,ls%relTol*eps)


### PR DESCRIPTION
@vvedula22 line_search implements the line search enhancement to Newton's method. I've implemented three algorithms to perform the "search" along the "line": backtracking, regula falsi, and bisection.

I basically grouped all of the functions in the Newton loop in MAIN.f into a new function called CALCKR (which stands for calculate K matrix and R vector). The Newton loop in MAIN.f then calls CALCKR, as well as some new functions that perform the line search. All the functionality is there (although I haven't completely tested it for bugs), but the code can probably be cleaned up and optimized, and also I did not write an interface to modify line search parameters (search algorithms, search tolerance, ...) from the svFSI input file.